### PR TITLE
Add configurable group settings and dynamic currency formatting

### DIFF
--- a/TEST_SCENARIO.md
+++ b/TEST_SCENARIO.md
@@ -18,8 +18,10 @@
 1. **Go to RoomLedger app**
 2. **Click "Create Group"**
 3. **Fill in details:**
+   - **Group Name:** Room 101
    - **Admin Name:** Ali
    - **Group Password:** roommates2024
+   - **Default Currency:** PKR — Pakistani Rupee
 4. **Add Members:**
    - Sara
    - Ahmed  

--- a/index.html
+++ b/index.html
@@ -84,16 +84,22 @@
                     <div class="setup-step">
                         <div class="step-header">
                             <div class="step-number">1</div>
-                            <div class="step-title">👤 Your Information</div>
+                            <div class="step-title">🛠️ Group Setup</div>
                         </div>
-                        <p class="step-description">Set up your admin account for the group</p>
-                        
+                        <p class="step-description">Name your room, create the admin account, and choose the default currency</p>
+
+                        <div class="form-group">
+                            <label>Group Name</label>
+                            <input type="text" id="groupName" placeholder="e.g., Room 101 or Karachi Apartment">
+                            <small class="form-hint">This name helps everyone recognize the shared space</small>
+                        </div>
+
                         <div class="form-group">
                             <label>Your Name (Group Admin)</label>
                             <input type="text" id="adminName" placeholder="Enter your full name">
                             <small class="form-hint">This will be your display name in the group</small>
                         </div>
-                        
+
                         <div class="form-group">
                             <label>Group Password</label>
                             <form onsubmit="event.preventDefault(); createGroup();">
@@ -103,6 +109,22 @@
                                 <span style="color: var(--apple-orange);">🔒</span>
                                 This password will be shared with all group members
                             </small>
+                        </div>
+
+                        <div class="form-group">
+                            <label>Default Currency</label>
+                            <select id="groupCurrency">
+                                <option value="PKR" selected>PKR — Pakistani Rupee</option>
+                                <option value="USD">USD — US Dollar</option>
+                                <option value="EUR">EUR — Euro</option>
+                                <option value="GBP">GBP — British Pound</option>
+                                <option value="AED">AED — UAE Dirham</option>
+                                <option value="INR">INR — Indian Rupee</option>
+                                <option value="AUD">AUD — Australian Dollar</option>
+                                <option value="CAD">CAD — Canadian Dollar</option>
+                                <option value="SAR">SAR — Saudi Riyal</option>
+                            </select>
+                            <small class="form-hint">You can update this later from the group settings</small>
                         </div>
                     </div>
                 
@@ -337,10 +359,10 @@
                         </div>
                         
                         <div class="form-group">
-                            <label>Amount (PKR)</label>
+                            <label>Amount (<span id="amountCurrencyLabel">PKR</span>)</label>
                             <div class="amount-input">
                                 <input type="number" id="debtAmount" placeholder="Enter amount" step="0.01" min="0">
-                                <div class="currency-symbol">PKR</div>
+                                <div class="currency-symbol" id="amountCurrencySymbol">PKR</div>
                             </div>
                             <small class="form-hint">Total amount that was paid</small>
                         </div>
@@ -430,7 +452,47 @@
                         </div>
                         <div class="card-subtitle">Add new members and manage existing ones</div>
                     </div>
-                    
+
+                    <!-- Group Settings Section -->
+                    <div class="manage-section">
+                        <div class="section-header">
+                            <div class="section-icon">⚙️</div>
+                            <div class="section-title">Group Settings</div>
+                        </div>
+                        <p class="section-description">Update the shared room name and default currency for this group</p>
+
+                        <div id="groupSettingsAdminNote" class="info hidden">Only group admins can update these settings.</div>
+
+                        <div class="form-group">
+                            <label>Group Name</label>
+                            <input type="text" id="groupNameInput" placeholder="e.g., Room 101 or Beach Apartment">
+                        </div>
+
+                        <div class="form-group">
+                            <label>Default Currency</label>
+                            <select id="groupCurrencySelect">
+                                <option value="PKR" selected>PKR — Pakistani Rupee</option>
+                                <option value="USD">USD — US Dollar</option>
+                                <option value="EUR">EUR — Euro</option>
+                                <option value="GBP">GBP — British Pound</option>
+                                <option value="AED">AED — UAE Dirham</option>
+                                <option value="INR">INR — Indian Rupee</option>
+                                <option value="AUD">AUD — Australian Dollar</option>
+                                <option value="CAD">CAD — Canadian Dollar</option>
+                                <option value="SAR">SAR — Saudi Riyal</option>
+                            </select>
+                            <small class="form-hint">All totals and settlements will use this currency</small>
+                        </div>
+
+                        <button class="btn btn-primary" id="saveGroupSettingsBtn" onclick="saveGroupSettings()">
+                            <span>💾</span>
+                            Save Settings
+                        </button>
+
+                        <div id="settingsError" class="message error"></div>
+                        <div id="settingsSuccess" class="message success"></div>
+                    </div>
+
                     <!-- Add New Member Section -->
                     <div class="manage-section">
                         <div class="section-header">
@@ -535,6 +597,91 @@
         let pendingMembers = [];
         let currentSettlement = null;
 
+        const DEFAULT_CURRENCY = 'PKR';
+
+        function getCurrentCurrency() {
+            if (currentGroup && currentGroup.currency) {
+                return currentGroup.currency;
+            }
+            return DEFAULT_CURRENCY;
+        }
+
+        function formatCurrency(amount, currencyOverride) {
+            const value = Number.isFinite(amount) ? amount : parseFloat(amount);
+            const safeValue = Number.isFinite(value) ? value : 0;
+            const currency = currencyOverride || getCurrentCurrency();
+
+            try {
+                return new Intl.NumberFormat(undefined, {
+                    style: 'currency',
+                    currency,
+                    currencyDisplay: 'symbol',
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
+                }).format(safeValue);
+            } catch (error) {
+                return `${currency} ${safeValue.toFixed(2)}`;
+            }
+        }
+
+        function getCurrencySymbol(currencyOverride) {
+            const currency = currencyOverride || getCurrentCurrency();
+
+            try {
+                const formatted = new Intl.NumberFormat(undefined, {
+                    style: 'currency',
+                    currency,
+                    currencyDisplay: 'narrowSymbol',
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 0
+                }).format(0);
+
+                const symbol = formatted.replace(/[\d\s.,]/g, '').trim();
+                return symbol || currency;
+            } catch (error) {
+                return currency;
+            }
+        }
+
+        function updateCurrencyDisplay() {
+            const currencyCode = getCurrentCurrency();
+            const currencySymbol = getCurrencySymbol(currencyCode);
+
+            const label = document.getElementById('amountCurrencyLabel');
+            if (label) {
+                label.textContent = currencyCode;
+            }
+
+            const symbolElement = document.getElementById('amountCurrencySymbol');
+            if (symbolElement) {
+                symbolElement.textContent = currencySymbol;
+            }
+
+            const totalExpensesElement = document.getElementById('totalExpenses');
+            if (totalExpensesElement) {
+                if (typeof totalExpensesElement.dataset.value === 'undefined') {
+                    totalExpensesElement.dataset.value = 0;
+                }
+                const rawValue = parseFloat(totalExpensesElement.dataset.value || 0);
+                totalExpensesElement.textContent = formatCurrency(rawValue, currencyCode);
+            }
+
+            const totalDebtElement = document.getElementById('totalDebtAmount');
+            if (totalDebtElement) {
+                if (typeof totalDebtElement.dataset.value === 'undefined') {
+                    totalDebtElement.dataset.value = 0;
+                }
+                const rawDebt = parseFloat(totalDebtElement.dataset.value || 0);
+                totalDebtElement.textContent = formatCurrency(rawDebt, currencyCode);
+            }
+
+            const subtitle = document.querySelector('.app-subtitle');
+            if (subtitle) {
+                const groupName = currentGroup && currentGroup.name ? currentGroup.name : 'Shared expenses';
+                subtitle.textContent = `${groupName} • Currency: ${currencyCode}`;
+            }
+        }
+
         // Auth functions
         function showAuthTab(tab) {
             document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
@@ -610,8 +757,14 @@
         function updateMemberCount() {
             const totalMembers = pendingMembers.length + 1; // +1 for admin
             const countDisplay = document.querySelector('.member-count');
+            const labelDisplay = document.querySelector('.counter-label');
+
             if (countDisplay) {
-                countDisplay.textContent = `${totalMembers} member${totalMembers !== 1 ? 's' : ''}`;
+                countDisplay.textContent = totalMembers;
+            }
+
+            if (labelDisplay) {
+                labelDisplay.textContent = totalMembers === 1 ? 'member' : 'members';
             }
         }
 
@@ -622,21 +775,30 @@
 
         function updateMembersList() {
             const membersList = document.getElementById('membersList');
-            membersList.innerHTML = pendingMembers.map(member => 
+            membersList.innerHTML = pendingMembers.map(member =>
                 `<div class="member-chip">
                     ${member}
                     <button class="remove-member" onclick="removeMember('${member}')">×</button>
                 </div>`
             ).join('');
+
+            updateMemberCount();
         }
 
         async function createGroup() {
+            const groupName = document.getElementById('groupName').value.trim();
             const adminName = document.getElementById('adminName').value.trim();
             const password = document.getElementById('groupPassword').value.trim();
+            const currency = document.getElementById('groupCurrency').value;
             const errorDiv = document.getElementById('registerError');
 
-            if (!adminName || !password) {
+            if (!groupName || !adminName || !password) {
                 errorDiv.textContent = 'Please fill in all fields';
+                return;
+            }
+
+            if (groupName.length < 2) {
+                errorDiv.textContent = 'Group name must be at least 2 characters long';
                 return;
             }
 
@@ -653,7 +815,7 @@
                 // Create group
                 const { data: groupData, error: groupError } = await supabase
                     .from('groups')
-                    .insert([{ password: password }])
+                    .insert([{ name: groupName, password: password, currency: currency }])
                     .select();
 
                 if (groupError) throw groupError;
@@ -679,8 +841,10 @@
                 showAuthTab('login');
                 
                 // Clear form
+                document.getElementById('groupName').value = '';
                 document.getElementById('adminName').value = '';
                 document.getElementById('groupPassword').value = '';
+                document.getElementById('groupCurrency').value = 'PKR';
                 pendingMembers = [];
                 updateMembersList();
 
@@ -760,9 +924,10 @@
         function showApp() {
             document.getElementById('authSection').classList.add('hidden');
             document.getElementById('appSection').classList.remove('hidden');
-            
+
             document.getElementById('welcomeMessage').textContent = `Welcome, ${currentUser.username}!`;
-            
+
+            updateCurrencyDisplay();
             updateDropdowns();
             loadDashboard();
             loadCurrentBalances();
@@ -836,7 +1001,11 @@
                 if (expensesError) throw expensesError;
                 
                 const totalExpenses = expenses.reduce((sum, exp) => sum + parseFloat(exp.amount), 0);
-                document.getElementById('totalExpenses').textContent = `PKR ${totalExpenses.toFixed(2)}`;
+                const totalExpensesElement = document.getElementById('totalExpenses');
+                if (totalExpensesElement) {
+                    totalExpensesElement.dataset.value = totalExpenses;
+                    totalExpensesElement.textContent = formatCurrency(totalExpenses);
+                }
                 
                 // Get member count
                 document.getElementById('memberCount').textContent = groupMembers.length;
@@ -901,10 +1070,12 @@
                 balances.slice(0, 3).forEach(balance => {
                     const balanceItem = document.createElement('div');
                     balanceItem.className = 'debt-item';
+                    const formattedAmount = formatCurrency(balance.amount);
+                    const displayAmount = balance.amount > 0 ? `+${formattedAmount}` : formattedAmount;
                     balanceItem.innerHTML = `
                         <div class="debt-name">${balance.name}</div>
                         <div class="debt-amount ${balance.amount >= 0 ? 'positive' : 'negative'}">
-                            ${balance.amount >= 0 ? '+' : ''}PKR ${balance.amount.toFixed(2)}
+                            ${displayAmount}
                         </div>
                     `;
                     balancesPreview.appendChild(balanceItem);
@@ -1025,11 +1196,9 @@
                 document.getElementById('debtDescription').value = '';
                 document.getElementById('debtAmount').value = '';
                 
-                // Refresh balances if on settle tab
-                const settleTab = document.getElementById('settleTab');
-                if (settleTab.classList.contains('active')) {
-                    loadCurrentBalances();
-                }
+                // Refresh views so dashboards stay in sync
+                loadDashboard();
+                loadCurrentBalances();
 
             } catch (error) {
                 errorDiv.textContent = 'Error adding expense: ' + error.message;
@@ -1041,7 +1210,7 @@
                 if (!supabase) {
                     throw new Error('Supabase client not initialized');
                 }
-                
+
                 const { data: transactions, error } = await supabase
                     .from('transactions')
                     .select(`
@@ -1054,7 +1223,6 @@
 
                 if (error) throw error;
 
-                // Calculate net balances
                 const balances = {};
                 groupMembers.forEach(member => {
                     balances[member.id] = { name: member.username, balance: 0 };
@@ -1065,45 +1233,48 @@
                     balances[transaction.to_member_id].balance += transaction.amount;
                 });
 
-                                   // Display enhanced balances
-                   const balancesDiv = document.getElementById('currentBalances');
-                   const totalDebtAmount = document.getElementById('totalDebtAmount');
-                   
-                   const balanceItems = Object.values(balances)
-                       .filter(person => Math.abs(person.balance) > 0.01)
-                       .map(person => {
-                           const isPositive = person.balance > 0;
-                           const status = isPositive ? 'owed-to' : 'owed';
-                           const text = isPositive ? 'is owed' : 'owes';
-                           return `<div class="debt-item">
-                               <div class="debt-item-header">
-                                   <div class="debt-person">${person.name}</div>
-                                   <div class="debt-status ${status}">${text}</div>
-                               </div>
-                               <div class="debt-amount ${isPositive ? 'positive' : 'negative'}">
-                                   PKR ${Math.abs(person.balance).toFixed(2)}
-                               </div>
-                           </div>`;
-                       });
-   
-                   // Calculate total debt amount
-                   const totalAmount = Object.values(balances)
-                       .filter(person => person.balance < 0)
-                       .reduce((sum, person) => sum + Math.abs(person.balance), 0);
-                   
-                   totalDebtAmount.textContent = `PKR ${totalAmount.toFixed(2)}`;
-   
-                                       if (balanceItems.length === 0) {
+                const balancesDiv = document.getElementById('currentBalances');
+                const totalDebtAmountElement = document.getElementById('totalDebtAmount');
+
+                const balanceItems = Object.values(balances)
+                    .filter(person => Math.abs(person.balance) > 0.01)
+                    .map(person => {
+                        const isPositive = person.balance > 0;
+                        const status = isPositive ? 'owed-to' : 'owed';
+                        const text = isPositive ? 'is owed' : 'owes';
+                        const amountDisplay = formatCurrency(Math.abs(person.balance));
+                        return `<div class="debt-item">
+                            <div class="debt-item-header">
+                                <div class="debt-person">${person.name}</div>
+                                <div class="debt-status ${status}">${text}</div>
+                            </div>
+                            <div class="debt-amount ${isPositive ? 'positive' : 'negative'}">
+                                ${amountDisplay}
+                            </div>
+                        </div>`;
+                    });
+
+                const totalAmount = Object.values(balances)
+                    .filter(person => person.balance < 0)
+                    .reduce((sum, person) => sum + Math.abs(person.balance), 0);
+
+                if (totalDebtAmountElement) {
+                    totalDebtAmountElement.dataset.value = totalAmount;
+                    totalDebtAmountElement.textContent = formatCurrency(totalAmount);
+                }
+
+                if (balancesDiv) {
+                    if (balanceItems.length === 0) {
                         balancesDiv.innerHTML = '<div class="debt-item" style="text-align: center; padding: var(--space-8);"><div style="font-size: 3rem; margin-bottom: var(--space-4);">✅</div><div style="font-weight: 600; color: var(--apple-green);">Everyone is settled up!</div><div style="color: var(--label-secondary); margin-top: var(--space-2);">No outstanding debts</div></div>';
                     } else {
                         balancesDiv.innerHTML = balanceItems.join('');
                     }
+                }
 
             } catch (error) {
                 console.error('Error loading balances:', error);
             }
         }
-
         async function calculateSettlement() {
             try {
                 if (!supabase) {
@@ -1234,11 +1405,12 @@
                 }
 
                 const totalAmount = settlements.reduce((sum, s) => sum + s.amount, 0);
+                const totalAmountDisplay = formatCurrency(totalAmount);
                 const settlementHtml = `
                     <div class="settlement-card">
                         <div class="settlement-header">
                             <div class="settlement-title">🧮 Smart Settlement Calculated!</div>
-                            <div class="settlement-amount">PKR ${totalAmount.toFixed(2)}</div>
+                            <div class="settlement-amount">${totalAmountDisplay}</div>
                         </div>
                         <div style="color: var(--label-secondary); margin-bottom: var(--space-4);">
                             Follow these steps to settle up with minimum transactions:
@@ -1252,7 +1424,7 @@
                                         <span class="step-from">${s.fromName}</span>
                                         <span> pays </span>
                                         <span class="step-to">${s.toName}</span>
-                                        <span class="step-amount"> PKR ${s.amount.toFixed(2)}</span>
+                                        <span class="step-amount">${formatCurrency(s.amount)}</span>
                                     </div>
                                 </div>
                             `).join('')}
@@ -1326,8 +1498,8 @@
 
                 const historyHtml = settlements.map(settlement => {
                     const date = new Date(settlement.created_at).toLocaleString();
-                    const settlementsHtml = settlement.settlement_data.map(s => 
-                        `<div style="margin: 4px 0;"><strong>${s.fromName}</strong> → <strong>${s.toName}</strong>: PKR ${s.amount.toFixed(2)}</div>`
+                    const settlementsHtml = settlement.settlement_data.map(s =>
+                        `<div style="margin: 4px 0;"><strong>${s.fromName}</strong> → <strong>${s.toName}</strong>: ${formatCurrency(s.amount)}</div>`
                     ).join('');
                     
                     return `<div class="history-item">
@@ -1343,9 +1515,46 @@
             }
         }
 
+        function populateGroupSettings() {
+            const nameInput = document.getElementById('groupNameInput');
+            const currencySelect = document.getElementById('groupCurrencySelect');
+            const adminNote = document.getElementById('groupSettingsAdminNote');
+            const saveButton = document.getElementById('saveGroupSettingsBtn');
+
+            if (!nameInput || !currencySelect) {
+                return;
+            }
+
+            const currentCurrency = getCurrentCurrency();
+
+            nameInput.value = currentGroup && currentGroup.name ? currentGroup.name : '';
+
+            const hasCurrencyOption = Array.from(currencySelect.options).some(option => option.value === currentCurrency);
+            if (!hasCurrencyOption) {
+                const option = document.createElement('option');
+                option.value = currentCurrency;
+                option.textContent = `${currentCurrency}`;
+                currencySelect.appendChild(option);
+            }
+            currencySelect.value = currentCurrency;
+
+            const isAdmin = currentUser && currentUser.is_admin;
+            nameInput.disabled = !isAdmin;
+            currencySelect.disabled = !isAdmin;
+
+            if (saveButton) {
+                saveButton.disabled = !isAdmin;
+            }
+
+            if (adminNote) {
+                adminNote.classList.toggle('hidden', !!isAdmin);
+            }
+        }
+
         function updateManageTab() {
+            populateGroupSettings();
             const currentMembersDiv = document.getElementById('currentMembers');
-            
+
             if (groupMembers.length === 0) {
                 currentMembersDiv.innerHTML = `
                     <div style="text-align: center; padding: var(--space-8); color: var(--gray-500);">
@@ -1381,6 +1590,62 @@
             }).join('');
 
             currentMembersDiv.innerHTML = membersHtml;
+        }
+
+        async function saveGroupSettings() {
+            const errorDiv = document.getElementById('settingsError');
+            const successDiv = document.getElementById('settingsSuccess');
+            const nameInput = document.getElementById('groupNameInput');
+            const currencySelect = document.getElementById('groupCurrencySelect');
+
+            if (!nameInput || !currencySelect) {
+                return;
+            }
+
+            errorDiv.textContent = '';
+            successDiv.textContent = '';
+
+            if (!currentUser || !currentUser.is_admin) {
+                errorDiv.textContent = 'Only admins can update group settings.';
+                return;
+            }
+
+            const groupName = nameInput.value.trim();
+            const currency = currencySelect.value;
+
+            if (groupName.length < 2) {
+                errorDiv.textContent = 'Group name must be at least 2 characters long.';
+                return;
+            }
+
+            try {
+                const { data: updatedGroup, error } = await supabase
+                    .from('groups')
+                    .update({
+                        name: groupName,
+                        currency: currency
+                    })
+                    .eq('id', currentGroup.id)
+                    .select()
+                    .single();
+
+                if (error) throw error;
+
+                currentGroup = { ...currentGroup, ...updatedGroup };
+
+                successDiv.textContent = 'Group settings updated successfully!';
+                populateGroupSettings();
+                updateCurrencyDisplay();
+                loadDashboard();
+                loadCurrentBalances();
+                loadHistory();
+
+                setTimeout(() => {
+                    successDiv.textContent = '';
+                }, 3000);
+            } catch (error) {
+                errorDiv.textContent = 'Error updating settings: ' + error.message;
+            }
         }
 
         async function addNewMember() {

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ RoomLedger is a lightweight, mobile-friendly web app that helps families, roomma
 - **Settlement History**: Track all past settlements
 - **Flexible Expense Splitting**: Split bills between selected group members
 - **Real-time Balances**: See who owes what instantly
+- **Room Preferences**: Name your room and pick the currency that fits your household
 
 ## 📱 Example Scenario
 
@@ -48,11 +49,11 @@ After setup, your app will be available at your Netlify URL (like `https://your-
 
 ## 🎯 How It Works
 
-1. **Create Group**: One person registers and adds family/roommate names
+1. **Create Group**: One person registers, names the shared room, chooses a currency, and adds family/roommate names
 2. **Shared Access**: Everyone uses the same group password to login
 3. **Track Expenses**: Anyone can add expenses and split them
 4. **Smart Settlement**: App calculates the minimum payments needed
-5. **Record & Repeat**: Confirm settlements and maintain history
+5. **Record & Repeat**: Confirm settlements, tweak settings anytime, and maintain history
 
 ## 🔧 Tech Stack
 

--- a/setup-instructions.md
+++ b/setup-instructions.md
@@ -104,6 +104,7 @@ POST https://your-app.netlify.app/.netlify/functions/smart-settlement
 
 1. **Create Test Group**:
    - Register with your name + family members
+   - Give the room a friendly **Group Name** and choose the **Default Currency**
    - Use strong group password
    - Test login with different usernames
 

--- a/styles.css
+++ b/styles.css
@@ -407,6 +407,75 @@ input::placeholder {
 }
 
 /* Member Management */
+.manage-section {
+    background: var(--gray-50);
+    border-radius: var(--radius-xl);
+    padding: var(--space-6);
+    margin-bottom: var(--space-6);
+    border: 1px solid var(--gray-200);
+    box-shadow: var(--shadow-sm);
+}
+
+.manage-section:last-of-type {
+    margin-bottom: 0;
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+}
+
+.section-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: var(--radius-full);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--primary-100);
+    color: var(--primary-600);
+    font-size: 1.25rem;
+    font-weight: 600;
+    box-shadow: var(--shadow-sm);
+}
+
+.section-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--gray-800);
+}
+
+.section-description {
+    color: var(--gray-500);
+    font-size: 0.95rem;
+    margin-bottom: var(--space-5);
+}
+
+.manage-section .form-group {
+    margin-bottom: var(--space-5);
+}
+
+.info {
+    background: rgba(14, 165, 233, 0.12);
+    color: var(--primary-700);
+    padding: var(--space-4);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(14, 165, 233, 0.2);
+    margin: var(--space-4) 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.info::before {
+    content: 'ℹ️';
+    font-size: 1rem;
+}
+
 .member-section {
     background: var(--gray-50);
     border-radius: var(--radius-xl);


### PR DESCRIPTION
## Summary
- add group naming and currency selection when creating a group and through a new manage tab settings panel
- introduce shared currency helpers so totals, balances, history, and settlements reflect the selected currency
- style the manage settings section and refresh documentation/test steps to highlight the new configuration options

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68c9915951488326b57d3be83cf5b8f5