### PR TITLE
Fix frontend styling connection issues

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,7 @@
   "outputDirectory": ".",
   "routes": [
     { "src": "/api/(.*)", "dest": "/api/$1" },
+    { "src": "/(.*)\.(css|js|png|jpg|jpeg|gif|svg|ico|webp|woff|woff2|ttf|eot)", "dest": "/$1.$2" },
     { "src": "/(.*)", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
Add Vercel route to serve static assets directly to fix styling issues on deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f069efb-90ff-4a3b-b513-918e4be0e4c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f069efb-90ff-4a3b-b513-918e4be0e4c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

