### PR TITLE
Fix frontend styling connection issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -974,6 +974,20 @@
             console.log('showApp() called');
             
             try {
+                // Inject runtime CSS override to guarantee visibility
+                const existingOverride = document.getElementById('app-visibility-override');
+                if (!existingOverride) {
+                    const style = document.createElement('style');
+                    style.id = 'app-visibility-override';
+                    style.textContent = `
+                        #appSection { display: block !important; visibility: visible !important; opacity: 1 !important; }
+                        #appSection .card { display: block !important; visibility: visible !important; opacity: 1 !important; }
+                        #appSection .tab-content { display: none; }
+                        #appSection .tab-content.active { display: block !important; }
+                    `;
+                    document.head.appendChild(style);
+                }
+
                 // Hide landing header
                 const header = document.querySelector('.header');
                 if (header) {


### PR DESCRIPTION
Force app content visibility and scroll into view after login to resolve the blank page issue.

The app section was rendering but not visible in the viewport, leading to a blank page after login. This change injects runtime CSS overrides to guarantee `#appSection` and its active tab content are displayed, hides the landing header, and scrolls the user directly to the app content.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f069efb-90ff-4a3b-b513-918e4be0e4c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f069efb-90ff-4a3b-b513-918e4be0e4c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>